### PR TITLE
사용자 문의 CRUD 기능 추가

### DIFF
--- a/src/api/service/inquiry.ts
+++ b/src/api/service/inquiry.ts
@@ -2,6 +2,10 @@ import { API_URL } from "@/constant";
 import { checkToken } from "@/utils/api";
 import axios from "axios";
 import endpoint from "../apiConfig";
+import {
+  ServerFetchRequestProps,
+  ServerPostRequestProps,
+} from "@/types/request";
 
 const inquiryAxios = axios.create({
   baseURL: `${API_URL}/api/`,
@@ -30,16 +34,26 @@ adminInquiryAxios.interceptors.response.use((res) => res.data);
 
 inquiryAxios.interceptors.response.use((res) => res.data);
 
-const getInquiriesByUser = async (userId: number) => {
+const getInquiriesByUser = async (
+  userId: number
+): Promise<Array<ServerFetchRequestProps>> => {
   return await inquiryAxios.get(`${endpoint.getInquiresUser}/${userId}`);
 };
 
-const createInquiryByUser = async (userId: number) => {
-  return await inquiryAxios.post(`${endpoint.createInquiryUser}/${userId}`);
+const createInquiryByUser = async (
+  userId: number,
+  inquiryInfo: ServerPostRequestProps
+): Promise<string> => {
+  return await inquiryAxios.post(
+    `${endpoint.createInquiryUser}/${userId}`,
+    inquiryInfo
+  );
 };
 
-const deleteInquiresByUser = async (userId: number) => {
-  return await inquiryAxios.delete(`${endpoint.deleteInquiryUser}/${userId}`);
+const deleteInquiresByUser = async (inquiryId: number): Promise<string> => {
+  return await inquiryAxios.delete(
+    `${endpoint.deleteInquiryUser}/${inquiryId}`
+  );
 };
 
 const getAllInquiresByAdmin = async () => {

--- a/src/app/(user)/request/ClientComponent.tsx
+++ b/src/app/(user)/request/ClientComponent.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import AbsoluteIcon from "@/components/common/AbsoluteIcon";
+import DeleteIcon from "@/components/common/DeleteIcon";
+import Section from "@/components/common/section";
+import Button from "@/components/user/button";
+import useUserFetchRequest from "@/components/user/hooks/request/useUserFetchRequest";
+import useUserPostRequest from "@/components/user/hooks/request/useUserPostRequest";
+import { ServerFetchRequestProps } from "@/types/request";
+import React from "react";
+
+const RequestView = ({
+  requestList,
+}: {
+  requestList: Array<ServerFetchRequestProps>;
+}) => {
+  const { deleteRequest } = useUserPostRequest();
+
+  if (!requestList || requestList.length === 0)
+    return <p>문의 내용이 없습니다.</p>;
+  return (
+    <div className="mt-2">
+      {requestList.map((r, idx) => {
+        return (
+          <>
+            <AbsoluteIcon
+              Icon={<DeleteIcon />}
+              position="top-right"
+              className="cursor-pointer"
+              //   문의 조회 api 수정 후 수정 필요
+              //   onClick={}
+            />
+            <p className="border-b">{r.title}</p>
+            <p>{r.content}</p>
+          </>
+        );
+      })}
+    </div>
+  );
+};
+
+const RequestCreate = () => {
+  const { requestInfo, createRequest, handleRequestInfo } =
+    useUserPostRequest();
+  const { title, content } = requestInfo;
+  return (
+    <form
+      className="my-2"
+      onSubmit={async (e) => {
+        e.preventDefault();
+        createRequest();
+      }}
+    >
+      <fieldset className="flex flex-col gap-5 my-2">
+        <legend className="font-bold">문의 작성</legend>
+        <div className="flex flex-col">
+          <label htmlFor="">제목: </label>
+          <input
+            type="text"
+            name="title"
+            className="bg-gray-200 rounded-sm h-11"
+            onChange={handleRequestInfo}
+            value={title}
+          />
+        </div>
+        <div className="flex flex-col">
+          <label htmlFor="">문의내용: </label>
+          <textarea
+            name="content"
+            className="bg-gray-200 rounded-sm h-48 resize-none"
+            onChange={handleRequestInfo}
+            value={content}
+          ></textarea>
+        </div>
+      </fieldset>
+      <Button color="primary" size="full" isRadius type="submit">
+        제출하기
+      </Button>
+    </form>
+  );
+};
+
+const ClientComponent = () => {
+  const { requestList, isLoading } = useUserFetchRequest();
+  if (isLoading) return <p>...loading</p>;
+  return (
+    <>
+      <Section>
+        <RequestCreate />
+      </Section>
+      <Section>
+        <RequestView requestList={requestList} />
+      </Section>
+    </>
+  );
+};
+
+export default ClientComponent;

--- a/src/app/(user)/request/ClientComponent.tsx
+++ b/src/app/(user)/request/ClientComponent.tsx
@@ -19,10 +19,12 @@ const RequestView = ({
   if (!requestList || requestList.length === 0)
     return <p>문의 내용이 없습니다.</p>;
   return (
-    <div className="mt-2">
+    <div className="my-5">
+      <p className="font-bold text-lg">문의조회</p>
       {requestList.map((r, idx) => {
         return (
-          <>
+          // key => requestId 로 수정 필요
+          <div key={`user_request_id_${idx}`} className="py-2">
             <AbsoluteIcon
               Icon={<DeleteIcon />}
               position="top-right"
@@ -32,7 +34,7 @@ const RequestView = ({
             />
             <p className="border-b">{r.title}</p>
             <p>{r.content}</p>
-          </>
+          </div>
         );
       })}
     </div>
@@ -52,7 +54,7 @@ const RequestCreate = () => {
       }}
     >
       <fieldset className="flex flex-col gap-5 my-2">
-        <legend className="font-bold">문의 작성</legend>
+        <legend className="font-bold text-lg">문의 작성</legend>
         <div className="flex flex-col">
           <label htmlFor="">제목: </label>
           <input
@@ -73,7 +75,13 @@ const RequestCreate = () => {
           ></textarea>
         </div>
       </fieldset>
-      <Button color="primary" size="full" isRadius type="submit">
+      <Button
+        color="primary"
+        size="full"
+        isRadius
+        type="submit"
+        disabled={!title || !content}
+      >
         제출하기
       </Button>
     </form>

--- a/src/app/(user)/request/page.tsx
+++ b/src/app/(user)/request/page.tsx
@@ -1,7 +1,19 @@
+import Section from "@/components/common/section";
+import FirstUserBanner from "@/components/user/FirstUserBanner";
+import Goback from "@/components/user/GoBack";
+import SectionHeader from "@/components/user/SectionHeader";
+import SectionHeaderWithBack from "@/components/user/SectionHeaderWithBack";
 import React from "react";
+import ClientComponent from "./ClientComponent";
 
 const RequestPage = () => {
-  return <div>문의하기 페이지</div>;
+  return (
+    <>
+      <SectionHeaderWithBack>문의하기</SectionHeaderWithBack>
+      <FirstUserBanner className="my-4" />
+      <ClientComponent />
+    </>
+  );
 };
 
 export default RequestPage;

--- a/src/app/(user)/reservation/check/page.tsx
+++ b/src/app/(user)/reservation/check/page.tsx
@@ -22,31 +22,7 @@ import useReservation from "@/components/user/reservation/useReservation";
 import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/components/common/AuthContext";
 import { useRouter } from "next/navigation";
-
-// ***this is temproal need to update!
-// const data: Array<ServerViewReservationProps> = [
-//   {
-//     reservationId: 1,
-//     restaurant_link:
-//       "https://www.google.com/maps/place/%EB%A7%88%EC%9E%A5%EB%8F%99+%ED%95%9C%EC%9A%B0%EC%B4%8C/data=!4m6!3m5!1s0x357ca4aab7a37341:0x57e6703998ac9ae1!8m2!3d37.570638!4d127.0412537!16s%2Fg%2F1tj4d_bn?entry=ttu&g_ep=EgoyMDI0MTAyOS4wIKXMDSoASAFQAw%3D%3D",
-//     adult_count: 2,
-//     child_count: 2,
-//     primary_date_time: "2024-12-31T04:00:00",
-//     secondary_date_time: "2024-12-31T05:00:00",
-//     status: "CONFIRMED",
-//   },
-//   {
-//     reservationId: 27,
-//     restaurant_link:
-//       "https://www.google.com/maps/place/%EC%9D%B4%EB%A7%88%ED%8A%B8+%EC%B2%AD%EA%B3%84%EC%B2%9C%EC%A0%90/data=!4m6!3m5!1s0x357ca34926396897:0x60f507c6a9bdf064!8m2!3d37.5710434!4d127.0222296!16s%2Fg%2F1tkp2xz1?entry=ttu&g_ep=EgoyMDI0MTEwNi4wIKXMDSoASAFQAw%3D%3D",
-//     adult_count: 1,
-//     child_count: 2,
-//     primary_date_time: "2024-01-01T01:00:00",
-//     secondary_date_time: "2024-01-01T02:00:00",
-//     available_date_time: "2024-01-01T02:00:00",
-//     status: "AVAILABLE",
-//   },
-// ];
+import SectionHeaderWithBack from "@/components/user/SectionHeaderWithBack";
 
 const ReservationCheckPage = () => {
   const [reservations, setReservations] = useState<Array<FormInfoProps>>([]);
@@ -84,10 +60,7 @@ const ReservationCheckPage = () => {
   }, [data, isSuccess]);
   return (
     <Section>
-      <Section.Text className="flex items-center gap-3" bold fontSize={20}>
-        <Goback />
-        예약확인
-      </Section.Text>
+      <SectionHeaderWithBack>예약확인</SectionHeaderWithBack>
       <FirstUserBanner className="mt-4" />
       {reservations.length > 0 ? (
         reservations.map((r, index) => {

--- a/src/components/common/AbsoluteIcon.tsx
+++ b/src/components/common/AbsoluteIcon.tsx
@@ -7,9 +7,22 @@ type AbsolutePosition =
   | "bottom-right"
   | "bottom-left";
 
-type AbsoluteIconProps = {
+interface AbsoluteIconPropsBase extends React.HTMLAttributes<HTMLDivElement> {
   Icon: React.ReactNode;
-} & ({ position: AbsolutePosition } | { customClassName: string });
+  className?: string;
+}
+
+interface AbsoluteIconPropsPosition extends AbsoluteIconPropsBase {
+  position: AbsolutePosition;
+}
+
+interface AbsoluteIconPropsCustomClassName extends AbsoluteIconPropsBase {
+  customClassName: string;
+}
+
+type AbsoluteIconProps =
+  | AbsoluteIconPropsPosition
+  | AbsoluteIconPropsCustomClassName;
 
 const POSITION_MAPPED: Record<AbsolutePosition, string> = {
   "top-right": "top-0 right-0",
@@ -18,8 +31,8 @@ const POSITION_MAPPED: Record<AbsolutePosition, string> = {
   "bottom-left": "bottom-0 left-0",
 };
 
-const AbsoluteIcon = ({ Icon, ...props }: AbsoluteIconProps) => {
-  let absIconClassNames = "absolute";
+const AbsoluteIcon = ({ Icon, className, ...props }: AbsoluteIconProps) => {
+  let absIconClassNames = `absolute ${className}`;
 
   if ("position" in props) {
     absIconClassNames = cls(absIconClassNames, POSITION_MAPPED[props.position]);

--- a/src/components/common/DeleteIcon.tsx
+++ b/src/components/common/DeleteIcon.tsx
@@ -1,0 +1,13 @@
+import cls from "classnames";
+
+const DeleteIcon = () => (
+  <div
+    className={cls(
+      "w-5 h-5 rounded-full bg-warn flex justify-center items-center text-white"
+    )}
+  >
+    <span className="material-symbols-outlined text-xl">&#xe5cd;</span>
+  </div>
+);
+
+export default DeleteIcon;

--- a/src/components/user/CheckIcon.tsx
+++ b/src/components/user/CheckIcon.tsx
@@ -3,7 +3,7 @@ import cls from "classnames";
 const CheckIcon = () => (
   <div
     className={cls(
-      "w-5 h-5 rounded-full bg-primary flex justify-center items-center text-white"
+      "w-5 h-5 rounded-full bg-primary flex justify-center items-center text-white "
     )}
   >
     <span className="material-symbols-outlined text-xl">&#xf88b;</span>

--- a/src/components/user/HomeHeader.tsx
+++ b/src/components/user/HomeHeader.tsx
@@ -13,25 +13,17 @@ const HomeHeader = ({ children }: HomeHeaderProps) => {
   const router = useRouter();
   const { isAuthenticated } = useAuth();
 
-  const handleClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    const { id } = e.target as HTMLDivElement;
-    if (id === "check") {
-      router.push(`reservation/${id}`);
-    } else {
-      // request 처리
-    }
-  };
-
   return (
     <header className="flex justify-between items-center">
       <p className="text-2xl font-extrabold">{children}</p>
       {isAuthenticated && (
-        <div
-          className="flex gap-4 font-bold cursor-pointer"
-          onClick={(e) => handleClick(e)}
-        >
-          <p id="request">문의하기</p>
-          <p id="check">예약확인</p>
+        <div className="flex gap-4 font-bold cursor-pointer">
+          <p id="request" onClick={() => router.push("/request")}>
+            문의하기
+          </p>
+          <p id="check" onClick={() => router.push("/reservation/check")}>
+            예약확인
+          </p>
         </div>
       )}
     </header>

--- a/src/components/user/SectionHeaderWithBack.tsx
+++ b/src/components/user/SectionHeaderWithBack.tsx
@@ -1,0 +1,13 @@
+import Section from "../common/section";
+import Goback from "./GoBack";
+
+const SectionHeaderWithBack = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <Section.Text className="flex items-center gap-3" bold fontSize={20}>
+      <Goback />
+      {children}
+    </Section.Text>
+  );
+};
+
+export default SectionHeaderWithBack;

--- a/src/components/user/hooks/request/useUserFetchRequest.ts
+++ b/src/components/user/hooks/request/useUserFetchRequest.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { getInquiriesByUser } from "@/api/service/inquiry";
+import { useAuth } from "@/components/common/AuthContext";
+import { ServerFetchRequestProps } from "@/types/request";
+import { useQuery } from "@tanstack/react-query";
+import React, { useEffect, useMemo, useState } from "react";
+
+const useUserFetchRequest = () => {
+  const { userId } = useAuth();
+  const { data = [], isLoading } = useQuery({
+    queryKey: ["user_fetch_request", userId],
+    queryFn: () => getInquiriesByUser(userId),
+    enabled: !!userId,
+  });
+  const [requestList, setRequestList] = useState<
+    Array<ServerFetchRequestProps>
+  >([]);
+
+  useEffect(() => {
+    if (data && data.length >= 1) {
+      setRequestList(data);
+    }
+  }, [data]);
+
+  return {
+    requestList,
+    isLoading,
+    updateRequestList: setRequestList,
+  };
+};
+
+export default useUserFetchRequest;

--- a/src/components/user/hooks/request/useUserPostRequest.ts
+++ b/src/components/user/hooks/request/useUserPostRequest.ts
@@ -1,0 +1,59 @@
+import {
+  createInquiryByUser,
+  deleteInquiresByUser,
+} from "@/api/service/inquiry";
+import { useAuth } from "@/components/common/AuthContext";
+import {
+  ServerFetchRequestProps,
+  ServerPostRequestProps,
+} from "@/types/request";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import React, { useCallback, useState } from "react";
+import toast from "react-hot-toast";
+
+const useUserPostRequest = () => {
+  const { userId } = useAuth();
+  const queryClient = useQueryClient();
+  const [requestInfo, setRequestInfo] = useState<ServerPostRequestProps>({
+    title: "",
+    content: "",
+  });
+
+  const handleRequestInfo = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setRequestInfo((prevState) => {
+      return {
+        ...prevState,
+        [e.target.name]: e.target.value,
+      };
+    });
+  };
+
+  const { mutate: createRequest } = useMutation({
+    mutationFn: () => createInquiryByUser(userId, requestInfo),
+    onSuccess: (res) => {
+      // post 요청 성공시 데이터 최신화
+      queryClient.invalidateQueries({
+        queryKey: ["user_fetch_request", userId],
+      });
+      toast.success(res);
+    },
+  });
+
+  const { mutate: deleteRequest } = useMutation({
+    mutationFn: (inquiryId: number) => deleteInquiresByUser(inquiryId),
+    onSuccess: (res) => {
+      toast.success(res);
+    },
+  });
+
+  return {
+    requestInfo,
+    createRequest,
+    handleRequestInfo,
+    deleteRequest,
+  };
+};
+
+export default useUserPostRequest;

--- a/src/components/user/hooks/request/useUserPostRequest.ts
+++ b/src/components/user/hooks/request/useUserPostRequest.ts
@@ -14,10 +14,12 @@ import toast from "react-hot-toast";
 const useUserPostRequest = () => {
   const { userId } = useAuth();
   const queryClient = useQueryClient();
-  const [requestInfo, setRequestInfo] = useState<ServerPostRequestProps>({
+  const initialRequestInfo = {
     title: "",
     content: "",
-  });
+  };
+  const [requestInfo, setRequestInfo] =
+    useState<ServerPostRequestProps>(initialRequestInfo);
 
   const handleRequestInfo = (
     e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
@@ -37,6 +39,7 @@ const useUserPostRequest = () => {
       queryClient.invalidateQueries({
         queryKey: ["user_fetch_request", userId],
       });
+      setRequestInfo(initialRequestInfo);
       toast.success(res);
     },
   });

--- a/src/types/request/index.ts
+++ b/src/types/request/index.ts
@@ -1,0 +1,10 @@
+interface ServerPostRequestProps {
+  title: string;
+  content: string;
+}
+
+interface ServerFetchRequestProps extends ServerPostRequestProps {
+  deleted: boolean;
+}
+
+export type { ServerPostRequestProps, ServerFetchRequestProps };


### PR DESCRIPTION
사용자는 로그인 후 `HomeHeader` 컴포넌트에서 문의하기 문구를 클릭 시 `/request` 페이지로 이동
- `useUserFetchRequest` 훅을 통해 문의 데이터 get api 호출
- `useUserPostRequest` 훅을 통해 문의 생성, 삭제 api 호출
    - 문의 삭제/생성 시 tanstackquery의 `useQueryClient` 훅을 통해 문의하기 get api가 stale 상태이더라도 데이터 최신화


todo
- `src/app/(user)/request/ClientComponent`파일 
  - `RequestCreate` 컴포넌트 추상화 
  - `RequestView` 컴포넌트 추상화
  - `RequestView` 컴포넌트에 `useUserPostRequest` 훅을 통해 삭제 api 호출 필요(삭제 api 수정 후)