### PR TITLE
관리자 문의 관리 기능 추가

### DIFF
--- a/src/api/service/inquiry.ts
+++ b/src/api/service/inquiry.ts
@@ -3,6 +3,7 @@ import { checkToken } from "@/utils/api";
 import axios from "axios";
 import endpoint from "../apiConfig";
 import {
+  ServerAdminFetchRequestProps,
   ServerFetchRequestProps,
   ServerPostRequestProps,
 } from "@/types/request";
@@ -56,12 +57,21 @@ const deleteInquiresByUser = async (inquiryId: number): Promise<string> => {
   );
 };
 
-const getAllInquiresByAdmin = async () => {
-  return await adminInquiryAxios.get(`${endpoint.getAllInquiresAdmin}`);
+const getAllInquiresByAdmin = async (): Promise<
+  Array<ServerAdminFetchRequestProps>
+> => {
+  const res = await adminInquiryAxios.get(`${endpoint.getAllInquiresAdmin}`);
+  return res.data;
 };
 
-const responseInquiryByAdmin = async (inquiryId: number) => {
-  return await adminInquiryAxios.post(`${endpoint.responseAdmin}/${inquiryId}`);
+const responseInquiryByAdmin = async (
+  inquiryId: number,
+  responseInfo: { responseContent: string }
+): Promise<ServerAdminFetchRequestProps & { responseContent: string }> => {
+  return await adminInquiryAxios.post(
+    `${endpoint.responseAdmin}/${inquiryId}`,
+    responseInfo
+  );
 };
 
 export {

--- a/src/app/admin/board/RequestView.tsx
+++ b/src/app/admin/board/RequestView.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import useFetchRequest from "@/components/admin/hooks/useFetchRequest";
-import React from "react";
+import RequestList from "@/components/admin/request";
+import Section from "@/components/common/section";
+import React, { useState } from "react";
 
 const RequestView = () => {
-  const { data } = useFetchRequest();
-  return <div>RequestView</div>;
+  return (
+    <Section className="flex flex-col gap-10">
+      <RequestList />
+    </Section>
+  );
 };
 
 export default RequestView;

--- a/src/components/admin/hooks/useFetchRequest.ts
+++ b/src/components/admin/hooks/useFetchRequest.ts
@@ -1,16 +1,28 @@
 import { getAllInquiresByAdmin } from "@/api/service/inquiry";
 import { useQuery, useSuspenseQuery } from "@tanstack/react-query";
-import React from "react";
+import React, { useMemo } from "react";
 
 const useFetchRequest = () => {
   // useSuspenseQuery
-  const { data } = useQuery({
+  const { data: requestList = [], isLoading } = useQuery({
     queryKey: ["admin_request_fetch_all"],
     queryFn: () => getAllInquiresByAdmin(),
   });
 
+  const responseList: { [key: number]: string } = useMemo(() => {
+    const res = requestList.reduce((acc, v) => {
+      if (v.responseContent) {
+        acc[v.id] = v.responseContent;
+      }
+      return acc;
+    }, {} as { [key: number]: string });
+    return res;
+  }, [requestList]);
+
   return {
-    data,
+    requestList,
+    isLoading,
+    responseList,
   };
 };
 

--- a/src/components/admin/hooks/usePostRequest.ts
+++ b/src/components/admin/hooks/usePostRequest.ts
@@ -1,0 +1,47 @@
+import { responseInquiryByAdmin } from "@/api/service/inquiry";
+import { useMutation } from "@tanstack/react-query";
+import React, { useState } from "react";
+import toast from "react-hot-toast";
+
+const usePostRequest = ({
+  responseList,
+}: {
+  responseList: { [key: number]: string };
+}) => {
+  const [responseContent, setResponseContent] = useState<{
+    [key: number]: string;
+  }>(responseList);
+
+  const handleResponse = (
+    e: React.ChangeEvent<HTMLTextAreaElement>,
+    id: number
+  ) => {
+    setResponseContent((prevState) => {
+      return {
+        ...prevState,
+        [id]: e.target.value,
+      };
+    });
+  };
+
+  const { mutate: responseRequest } = useMutation({
+    mutationFn: ({ requestId }: { requestId: number }) => {
+      const id = Number(requestId);
+      const formData = {
+        responseContent: responseContent[id],
+      };
+      return responseInquiryByAdmin(requestId, formData);
+    },
+    onSuccess: () => {
+      toast.success("문의 답변 성공!");
+    },
+  });
+
+  return {
+    handleResponse,
+    responseContent,
+    responseRequest,
+  };
+};
+
+export default usePostRequest;

--- a/src/components/admin/request/index.tsx
+++ b/src/components/admin/request/index.tsx
@@ -1,0 +1,79 @@
+import { ServerAdminFetchRequestProps } from "@/types/request";
+import useFetchRequest from "../hooks/useFetchRequest";
+import usePostRequest from "../hooks/usePostRequest";
+import { isostringToDateTime } from "@/utils/reservation";
+import AbsoluteIcon from "@/components/common/AbsoluteIcon";
+import CheckIcon from "@/components/user/CheckIcon";
+
+const RequestItem = ({
+  children,
+  requestInfo,
+}: {
+  children: React.ReactNode;
+  requestInfo: ServerAdminFetchRequestProps;
+}) => {
+  return (
+    <div className="flex flex-col">
+      <div className="flex justify-between">
+        <p>{`문의번호: ${requestInfo.id}`}</p>
+        <p>{isostringToDateTime(requestInfo.createdAt)}</p>
+      </div>
+      <p>{`제목: ${requestInfo.title}`}</p>
+      <div className="h-20 bg-gray-300 rounded px-2 py-2 overflow-auto">
+        {requestInfo.content}
+      </div>
+      {children}
+    </div>
+  );
+};
+
+const ResponseTextArea = ({
+  requestId,
+  responseList,
+}: {
+  requestId: number;
+  responseList: { [key: number]: string };
+}) => {
+  const { handleResponse, responseContent, responseRequest } = usePostRequest({
+    responseList,
+  });
+  return (
+    <>
+      <AbsoluteIcon
+        Icon={<CheckIcon />}
+        customClassName="top-[10px] right-0"
+        className="cursor-pointer"
+        onClick={() => responseRequest({ requestId })}
+      />
+      <textarea
+        name={`request_comment_${requestId}`}
+        id={`request_comment_${requestId}`}
+        className="resize-none bg-gray-200 rounded p-2 mt-4"
+        rows={3}
+        placeholder="문의에 대한 답변 작성 후 오른쪽 상단 체크 버튼을 눌러주세요."
+        value={responseContent[requestId] || ""}
+        onChange={(e) => handleResponse(e, requestId)}
+      ></textarea>
+    </>
+  );
+};
+
+const RequestList = () => {
+  const { requestList, isLoading, responseList } = useFetchRequest();
+
+  if (isLoading) return <p>...loading</p>;
+  if (!requestList.length) return <p>문의 내용이 없습니다.</p>;
+  return (
+    <>
+      {requestList.map((r) => {
+        return (
+          <RequestItem requestInfo={r} key={`admin_request_item_${r.id}`}>
+            <ResponseTextArea requestId={r.id} responseList={responseList} />
+          </RequestItem>
+        );
+      })}
+    </>
+  );
+};
+
+export default RequestList;

--- a/src/components/common/AbsoluteIcon.tsx
+++ b/src/components/common/AbsoluteIcon.tsx
@@ -10,6 +10,7 @@ type AbsolutePosition =
 interface AbsoluteIconPropsBase extends React.HTMLAttributes<HTMLDivElement> {
   Icon: React.ReactNode;
   className?: string;
+  onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
 }
 
 interface AbsoluteIconPropsPosition extends AbsoluteIconPropsBase {
@@ -31,7 +32,12 @@ const POSITION_MAPPED: Record<AbsolutePosition, string> = {
   "bottom-left": "bottom-0 left-0",
 };
 
-const AbsoluteIcon = ({ Icon, className, ...props }: AbsoluteIconProps) => {
+const AbsoluteIcon = ({
+  Icon,
+  className,
+  onClick,
+  ...props
+}: AbsoluteIconProps) => {
   let absIconClassNames = `absolute ${className}`;
 
   if ("position" in props) {
@@ -41,7 +47,9 @@ const AbsoluteIcon = ({ Icon, className, ...props }: AbsoluteIconProps) => {
   }
   return (
     <div className={cls("relative")}>
-      <div className={absIconClassNames}>{Icon}</div>
+      <div className={absIconClassNames} onClick={onClick}>
+        {Icon}
+      </div>
     </div>
   );
 };

--- a/src/types/request/index.ts
+++ b/src/types/request/index.ts
@@ -7,4 +7,14 @@ interface ServerFetchRequestProps extends ServerPostRequestProps {
   deleted: boolean;
 }
 
-export type { ServerPostRequestProps, ServerFetchRequestProps };
+interface ServerAdminFetchRequestProps extends ServerFetchRequestProps {
+  id: number;
+  createdAt: string;
+  responseContent?: string;
+}
+
+export type {
+  ServerPostRequestProps,
+  ServerFetchRequestProps,
+  ServerAdminFetchRequestProps,
+};


### PR DESCRIPTION
관리자는 로그인 후 사이드바 `문의하기` 클릭 시 `/admin/board?category=request` 페이지로 이동
- 랜딩페이지: `src/app/admin/board/RequestView.tsx`
- 컴포넌트: `/src/components/dmin/request/index.tsx` 
- `RequestList`: 문의를 받아와 화면에 렌더링
- `RequestItem`: 문의에 대한 정보를 받아 렌더링
- `ResponseTextArea`: 관리자가 문의에 대한 답변을 하기위한 컴포넌트

