### PR TITLE
ReserveationFrom 컴포넌트 리팩토링

### DIFF
--- a/src/app/(user)/registration/layout.tsx
+++ b/src/app/(user)/registration/layout.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 const RegistrationLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <Section>
+    <Section className="h-full flex flex-col">
       <Goback />
       {children}
     </Section>

--- a/src/components/common/form/index.tsx
+++ b/src/components/common/form/index.tsx
@@ -22,7 +22,6 @@ interface FormInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   type?: "text" | "date" | "time";
   placeholder?: string;
   className?: string;
-  seperate?: boolean;
 }
 
 // ***research
@@ -56,19 +55,11 @@ const FormInput = ({
   label,
   type = "text",
   placeholder,
-  seperate,
   name,
   ...rest
 }: FormInputProps) => {
   return (
-    <div
-      className={cls(
-        {
-          "border-r mr-2": seperate,
-        },
-        "w-full"
-      )}
-    >
+    <div className={cls("w-full")}>
       <p className="text-[10px] font-bold">{label}</p>
       <input
         className={cls("w-full", {
@@ -87,6 +78,7 @@ const FormFieldContainer = ({
   multiple = false,
   isSelectedTime = false,
 }: FormFieldContainerProps) => {
+  const childrenArray = React.Children.toArray(children);
   return (
     <>
       {isSelectedTime && (
@@ -106,7 +98,16 @@ const FormFieldContainer = ({
           }
         )}
       >
-        {children}
+        {childrenArray.map((child, idx) => {
+          return (
+            <React.Fragment key={`temporal_idx_key_${idx}`}>
+              {child}
+              {idx < childrenArray.length - 1 && (
+                <div className="w-[1px] bg-[#717171] mx-3"></div>
+              )}
+            </React.Fragment>
+          );
+        })}
       </div>
     </>
   );

--- a/src/components/user/hooks/reservationForm/useReservationForm.ts
+++ b/src/components/user/hooks/reservationForm/useReservationForm.ts
@@ -1,0 +1,95 @@
+import { FormInfoProps, ReservationStatus } from "@/types/reservation";
+import {
+  reservationClientToServerData,
+  seperateIsostring,
+} from "@/utils/reservation";
+import React, { useCallback, useMemo, useState } from "react";
+import useUserPostReservation from "../useUserPostReservation";
+import { useRouter } from "next/navigation";
+
+const formInfoDefault = {
+  id: 0,
+  link: "",
+  adults: 0,
+  kids: 0,
+  primaryDateTime: "",
+  secondaryDateTime: "",
+  tertiaryDateTime: "",
+  status: "WAITING" as ReservationStatus,
+};
+
+const useReservationForm = (formInfo: FormInfoProps = formInfoDefault) => {
+  const { createReservation } = useUserPostReservation();
+  const router = useRouter();
+  const initialInfo = useMemo(() => {
+    return {
+      ...formInfo,
+      pDate: seperateIsostring(formInfo?.primaryDateTime).date,
+      pTime: seperateIsostring(formInfo?.primaryDateTime).time,
+      sDate: seperateIsostring(formInfo?.secondaryDateTime).date,
+      sTime: seperateIsostring(formInfo?.secondaryDateTime).time,
+      tDate: seperateIsostring(formInfo?.tertiaryDateTime).date,
+      tTime: seperateIsostring(formInfo?.tertiaryDateTime).time,
+    };
+  }, [formInfo]);
+
+  const [formData, setFormData] = useState(initialInfo);
+  const { pDate, pTime, sDate, sTime, tDate, tTime } = formData;
+
+  const handleChange = useCallback((field: string) => {
+    return (e: React.ChangeEvent<HTMLInputElement>) => {
+      const { value } = e.target;
+
+      setFormData((prevState) => {
+        return {
+          ...prevState,
+          [field]: value,
+        };
+      });
+    };
+  }, []);
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const data = reservationClientToServerData(formData);
+
+    createReservation(data, {
+      onSuccess: () => router.push("/reservation/success"),
+    });
+  };
+
+  const dateTimeFields: Array<{
+    date: string;
+    time: string;
+    dateField: string;
+    timeField: string;
+  }> = [
+    {
+      date: pDate,
+      time: pTime,
+      dateField: "pDate",
+      timeField: "pTime",
+    },
+    {
+      date: sDate,
+      time: sTime,
+      dateField: "sDate",
+      timeField: "sTime",
+    },
+    {
+      date: tDate,
+      time: tTime,
+      dateField: "tDate",
+      timeField: "tTime",
+    },
+  ];
+
+  return {
+    formData,
+    handleChange,
+    handleSubmit,
+    dateTimeFields,
+  };
+};
+
+export default useReservationForm;

--- a/src/components/user/hooks/reservationForm/useReservationForm.ts
+++ b/src/components/user/hooks/reservationForm/useReservationForm.ts
@@ -1,5 +1,6 @@
 import { FormInfoProps, ReservationStatus } from "@/types/reservation";
 import {
+  dateAndTimeToIsostring,
   reservationClientToServerData,
   seperateIsostring,
 } from "@/utils/reservation";
@@ -49,11 +50,37 @@ const useReservationForm = (formInfo: FormInfoProps = formInfoDefault) => {
     };
   }, []);
 
+  const reformedToFormInfo = (): FormInfoProps => {
+    return {
+      id: formInfo.id,
+      adults: formData.adults,
+      kids: formData.kids,
+      link: formData.link,
+      primaryDateTime: dateAndTimeToIsostring(formData.pDate, formData.pTime),
+      status: "WAITING",
+      ...(formData.sDate &&
+        formData.sTime && {
+          secondaryDateTime: dateAndTimeToIsostring(
+            formData.sDate,
+            formData.sTime
+          ),
+        }),
+      ...(formData.tDate &&
+        formData.tTime && {
+          tertiaryDateTime: dateAndTimeToIsostring(
+            formData.tDate,
+            formData.tTime
+          ),
+        }),
+    };
+  };
+
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const data = reservationClientToServerData(formData);
+    const data: FormInfoProps = reformedToFormInfo();
+    const dataToServer = reservationClientToServerData(data);
 
-    createReservation(data, {
+    createReservation(dataToServer, {
       onSuccess: () => router.push("/reservation/success"),
     });
   };

--- a/src/components/user/hooks/useUserFetchReservation.ts
+++ b/src/components/user/hooks/useUserFetchReservation.ts
@@ -41,15 +41,13 @@ const useUserFetchReservation = ({
         link: d.restaurant_link,
         status: d.status,
         primaryDateTime: d.primary_date_time,
-        ...(d.secondary_date_time
-          ? { secondaryDateTime: d.secondary_date_time }
-          : {}),
-        ...(d.tertiary_date_time
-          ? { tertiaryDateTime: d.tertiary_date_time }
-          : {}),
-        ...(d.available_date_time
-          ? { availableDateTime: d.available_date_time }
-          : {}),
+        ...(d.secondary_date_time && {
+          secondaryDateTime: d.secondary_date_time,
+        }),
+        ...(d.tertiary_date_time && { tertiaryDateTime: d.tertiary_date_time }),
+        ...(d.available_date_time && {
+          availableDateTime: d.available_date_time,
+        }),
       };
     },
     []

--- a/src/components/user/hooks/useUserPostReservation.ts
+++ b/src/components/user/hooks/useUserPostReservation.ts
@@ -1,26 +1,35 @@
 import {
   confirmReservationBuUser,
+  createReservationByUser,
   getReservationInfoByUser,
 } from "@/api/service/reservation";
 import { useAuth } from "@/components/common/AuthContext";
+import { ServerReservationProps } from "@/types/reservation";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
-const useUserPostReservation = ({
-  reservationId,
-}: {
-  reservationId: number;
-}) => {
+const useUserPostReservation = () => {
   const router = useRouter();
+  const { userId } = useAuth();
 
   const { mutate: confirmReservation } = useMutation({
-    mutationFn: () => confirmReservationBuUser(reservationId),
+    mutationFn: (id: number) => confirmReservationBuUser(id),
     onSuccess: () => {
       router.replace("/reservation/success/done");
     },
   });
 
-  return { confirmReservation };
+  const { mutate: createReservation } = useMutation({
+    mutationFn: (data: ServerReservationProps) => {
+      console.log("send data: ", data);
+      return createReservationByUser(data, userId);
+    },
+    // onSuccess: () => {
+    //   router.push("/reservation/success");
+    // },
+  });
+
+  return { confirmReservation, createReservation };
 };
 
 export default useUserPostReservation;

--- a/src/components/user/registration/RegistrationManager.tsx
+++ b/src/components/user/registration/RegistrationManager.tsx
@@ -32,29 +32,33 @@ const RegistrationManager = ({ type }: { type: "regis" | "login" }) => {
 
   return (
     <>
-      <form onSubmit={handleSubmit}>
+      <form onSubmit={handleSubmit} className="relative h-full">
         <div className="px-5">
           <LoginForm info={info} handleChange={handleInputChange} />
         </div>
-        {type === "regis" ? (
-          <div className="text-center text-sm">
-            <p className="">이미 아이디가 있으신 가요?</p>
-            <p
-              className="text-[#575757] border-b font-bold inline cursor-pointer"
-              onClick={() => router.push("/registration/login")}
-            >
-              로그인 하기
-            </p>
-          </div>
-        ) : null}
-        <div>
-          {loading ? (
-            "...loading"
-          ) : (
-            <Button color="primary" size="lg" isRadius type="submit">
-              {type === "regis" ? "회원가입" : "로그인"}하기
-            </Button>
+        <div className="absolute bottom-10 w-full">
+          {type === "regis" && (
+            <div className="pb-5">
+              <div className="text-center text-sm">
+                <p className="">이미 아이디가 있으신 가요?</p>
+                <p
+                  className="text-[#575757] border-b font-bold inline cursor-pointer"
+                  onClick={() => router.push("/registration/login")}
+                >
+                  로그인 하기
+                </p>
+              </div>
+            </div>
           )}
+          <div>
+            {loading ? (
+              "...loading"
+            ) : (
+              <Button color="primary" size="lg" isRadius type="submit">
+                {type === "regis" ? "회원가입" : "로그인"}하기
+              </Button>
+            )}
+          </div>
         </div>
       </form>
     </>

--- a/src/components/user/reservation/DateTimeUI.tsx
+++ b/src/components/user/reservation/DateTimeUI.tsx
@@ -21,7 +21,6 @@ const DateTimeUI = ({
       <Form.Input
         label={`날짜`}
         type="date"
-        seperate
         value={date}
         onChange={onDateChange}
         disabled={disabled}

--- a/src/components/user/reservation/ReservationConfirmButton.tsx
+++ b/src/components/user/reservation/ReservationConfirmButton.tsx
@@ -5,25 +5,26 @@ import { isostringToDateTime } from "@/utils/reservation";
 import Button from "../button";
 
 const ReservationConfirmButton = ({
-  formInfo,
+  id,
   status,
   nth,
   dateTime,
 }: {
-  formInfo: FormInfoProps;
+  id: number;
   status: ReservationStatus;
   nth: number;
   dateTime: string;
 }) => {
   const router = useRouter();
-  const { id } = formInfo;
-  const { confirmReservation } = useUserPostReservation({ reservationId: id });
+  const { confirmReservation } = useUserPostReservation();
 
   const handleClick = () => {
     if (window.location.pathname.includes("check")) {
       router.push(`/reservation/verify?reservationId=${id}&nth=${nth}`);
     } else if (window.location.pathname.includes("verify")) {
-      confirmReservation();
+      confirmReservation(id, {
+        onSuccess: () => router.replace("/reservation/success/done"),
+      });
     }
   };
 

--- a/src/components/user/reservation/ReservationForm.tsx
+++ b/src/components/user/reservation/ReservationForm.tsx
@@ -1,148 +1,32 @@
 "use client";
 
 import Form from "@/components/common/form";
-import {
-  FormInfoProps,
-  ReservationFormProps,
-  ReservationStatus,
-  ServerReservationProps,
-} from "@/types/reservation";
-import {
-  dateAndTimeToIsostring,
-  isostringToDateTime,
-  seperateIsostring,
-} from "@/utils/reservation";
+import { ReservationFormProps } from "@/types/reservation";
+import { dateAndTimeToIsostring } from "@/utils/reservation";
 import React, { useCallback, useMemo, useState } from "react";
 import DateTimeUI from "./DateTimeUI";
 import Button from "../button";
-import useReservation from "./useReservation";
 import { useAuth } from "@/components/common/AuthContext";
 import { RESERVATION_STATUS } from "@/constant";
 import Badge from "@/components/common/badge";
-import Link from "next/link";
-import { useRouter } from "next/navigation";
-import useUserPostReservation from "../hooks/useUserPostReservation";
 import ReservationConfirmButton from "./ReservationConfirmButton";
+import useReservationForm from "../hooks/reservationForm/useReservationForm";
 
 const ReservationForm = ({
-  formInfo = {
-    id: 0,
-    link: "",
-    adults: 0,
-    kids: 0,
-    primaryDateTime: "",
-    secondaryDateTime: "",
-    tertiaryDateTime: "",
-    status: "WAITING" as ReservationStatus,
-  },
+  formInfo,
   controlable = false,
   nth = 1,
 }: ReservationFormProps) => {
-  const initialInfo = useMemo(() => {
-    return {
-      ...formInfo,
-      pDate: seperateIsostring(formInfo?.primaryDateTime).date,
-      pTime: seperateIsostring(formInfo?.primaryDateTime).time,
-      sDate: seperateIsostring(formInfo?.secondaryDateTime).date,
-      sTime: seperateIsostring(formInfo?.secondaryDateTime).time,
-      tDate: seperateIsostring(formInfo?.tertiaryDateTime).date,
-      tTime: seperateIsostring(formInfo?.tertiaryDateTime).time,
-    };
-  }, [formInfo]);
+  const { formData, handleChange, handleSubmit, dateTimeFields } =
+    useReservationForm(formInfo);
 
   const { isAuthenticated } = useAuth();
-  const { createReservation } = useReservation();
-  const [formData, setFormData] = useState(initialInfo);
-  const {
-    link,
-    adults,
-    kids,
-    pDate,
-    pTime,
-    sDate,
-    sTime,
-    tDate,
-    tTime,
-    status,
-    availableDateTime,
-  } = formData;
+  const { id, link, adults, kids, status, availableDateTime } = formData;
 
   const isControllable = useMemo(
     (): boolean => isAuthenticated && controlable,
     [isAuthenticated, controlable]
   );
-
-  const handleChange = useCallback((field: string) => {
-    return (e: React.ChangeEvent<HTMLInputElement>) => {
-      const { value } = e.target;
-
-      setFormData((prevState) => {
-        return {
-          ...prevState,
-          [field]: value,
-        };
-      });
-    };
-  }, []);
-
-  const handleSubmit = useCallback(
-    (e: React.FormEvent<HTMLFormElement>) => {
-      e.preventDefault();
-      const data: ServerReservationProps = {
-        restaurant_link: link,
-        adult_count: adults,
-        child_count: kids,
-        primary_date_time: pDate + "T" + pTime + ":00",
-        ...(sDate && sTime
-          ? { secondary_date_time: sDate + "T" + sTime + ":00" }
-          : {}),
-        // tDate와 tTime이 있는 경우에만 추가
-        ...(tDate && tTime
-          ? { tertiary_date_time: tDate + "T" + tTime + ":00" }
-          : {}),
-      };
-
-      createReservation(data);
-    },
-    [
-      link,
-      adults,
-      kids,
-      pDate,
-      pTime,
-      sDate,
-      sTime,
-      tDate,
-      tTime,
-      createReservation,
-    ]
-  );
-
-  const dateTimeFields: Array<{
-    date: string;
-    time: string;
-    dateField: string;
-    timeField: string;
-  }> = [
-    {
-      date: pDate,
-      time: pTime,
-      dateField: "pDate",
-      timeField: "pTime",
-    },
-    {
-      date: sDate,
-      time: sTime,
-      dateField: "sDate",
-      timeField: "sTime",
-    },
-    {
-      date: tDate,
-      time: tTime,
-      dateField: "tDate",
-      timeField: "tTime",
-    },
-  ];
 
   return (
     <Form
@@ -176,7 +60,6 @@ const ReservationForm = ({
         <Form.Input
           label="성인"
           placeholder="0"
-          seperate
           value={adults}
           onChange={handleChange("adults")}
           disabled={!isControllable}
@@ -212,7 +95,7 @@ const ReservationForm = ({
           );
         })}
       <ReservationConfirmButton
-        formInfo={formInfo}
+        id={id}
         status={status}
         nth={nth}
         dateTime={availableDateTime ?? ""}

--- a/src/components/user/reservation/useReservation.ts
+++ b/src/components/user/reservation/useReservation.ts
@@ -20,16 +20,6 @@ const useReservation = () => {
     },
   });
 
-  // useQuery 사용시 홈페이지에서 사용하는 ReservationForm이 사용되고 컴포넌트가 마운트되며
-  // 로그인 후 이 쿼리가 실행되고 있다. 따라서 이 로직을 분리하거나
-  // enabled값을 통해 언제 이 쿼리를 실행할지에 대한 생각 필요
-  // const { data: userReservationList } = useQuery({
-  //   queryKey: ["reseration", userId],
-  //   queryFn: () => getReservationInfoByUser(userId),
-  //   enabled: !!userId,
-  //   staleTime: 0,
-  // });
-
   return { createReservation };
 };
 

--- a/src/types/reservation/index.ts
+++ b/src/types/reservation/index.ts
@@ -20,6 +20,15 @@ interface ReservationDateTimeProps {
 
 type FormInfoProps = ReservationBaseProps & ReservationDateTimeProps;
 
+interface FormInfoInputHandleProps extends FormInfoProps {
+  pDate: string;
+  pTime: string;
+  sDate?: string;
+  sTime?: string;
+  tDate?: string;
+  tTime?: string;
+}
+
 interface ReservationAdminData extends FormInfoProps {
   createdAt: string;
   userId: number;
@@ -78,4 +87,5 @@ export type {
   ReservationDateTimeProps,
   ServerReservationUpdateProps,
   ServerUpdateReservationProps,
+  FormInfoInputHandleProps,
 };

--- a/src/utils/reservation.ts
+++ b/src/utils/reservation.ts
@@ -55,19 +55,23 @@ const dateAndTimeToIsostring = (date: string, time: string) => {
 };
 
 const reservationClientToServerData = (
-  reservationInfo: FormInfoInputHandleProps
+  reservationInfo: FormInfoProps
 ): ServerReservationProps => {
-  const { link, adults, kids, pDate, pTime, sDate, sTime, tDate, tTime } =
-    reservationInfo;
+  const {
+    link,
+    adults,
+    kids,
+    primaryDateTime,
+    secondaryDateTime,
+    tertiaryDateTime,
+  } = reservationInfo;
   return {
     restaurant_link: link,
     adult_count: adults,
     child_count: kids,
-    primary_date_time: pDate + "T" + pTime + ":00",
-    ...(sDate &&
-      sTime && { secondary_date_time: dateAndTimeToIsostring(sDate, sTime) }),
-    ...(tDate &&
-      tTime && { tertiary_date_time: dateAndTimeToIsostring(tDate, tTime) }),
+    primary_date_time: primaryDateTime,
+    ...(secondaryDateTime && { secondary_date_time: secondaryDateTime }),
+    ...(tertiaryDateTime && { tertiary_date_time: tertiaryDateTime }),
   };
 };
 

--- a/src/utils/reservation.ts
+++ b/src/utils/reservation.ts
@@ -1,9 +1,11 @@
 import {
+  FormInfoInputHandleProps,
   FormInfoProps,
   NegativeReservationStatus,
   PositiveReservationStatus,
   ReservationAdminData,
   ReservationStatus,
+  ServerReservationProps,
 } from "@/types/reservation";
 
 const seperateIsostring = (dateTime?: string) => {
@@ -52,10 +54,28 @@ const dateAndTimeToIsostring = (date: string, time: string) => {
   return `${date}T${time}`;
 };
 
+const reservationClientToServerData = (
+  reservationInfo: FormInfoInputHandleProps
+): ServerReservationProps => {
+  const { link, adults, kids, pDate, pTime, sDate, sTime, tDate, tTime } =
+    reservationInfo;
+  return {
+    restaurant_link: link,
+    adult_count: adults,
+    child_count: kids,
+    primary_date_time: pDate + "T" + pTime + ":00",
+    ...(sDate &&
+      sTime && { secondary_date_time: dateAndTimeToIsostring(sDate, sTime) }),
+    ...(tDate &&
+      tTime && { tertiary_date_time: dateAndTimeToIsostring(tDate, tTime) }),
+  };
+};
+
 export {
   seperateIsostring,
   getBadgeColor,
   pickReservationInfo,
   isostringToDateTime,
   dateAndTimeToIsostring,
+  reservationClientToServerData,
 };


### PR DESCRIPTION
사용자 페이지에서 예약 조회/생성/상태변경을 위한 `ReservationFrom` 컴포넌트를 리팩토링 하였습니다.
- `useReservationForm` 훅에서 state 관리하여 UI와 state 관리 분리


- 추가적으로 사용자의 회원가입/로그인 페이지에서 버튼을 하단에 위치시켰습니다.
- 모바일 접속시 input필드에 값을 입력할 경우에도 버튼을 아래에 위치시킬수 있는 수정이 필요합니다.
- https://www.notion.so/J_Reservation-12ac9f3dc9dd80239ba5c6e09e469705?p=12ac9f3dc9dd8096bd07c5e9a0a703fe&pm=s